### PR TITLE
fix: changed back IonRouter component and added 8 decimals support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "description": "Mobile app for Protokol NFT plugins",
   "license": "CC BY-NC-SA 4.0",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "engines": {
     "node": ">=12.20.1"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Redirect, Route, Switch } from 'react-router-dom';
 import { Plugins } from '@capacitor/core';
 import { ScreenOrientation } from '@ionic-native/screen-orientation';
 import { IonApp, IonRouterOutlet, isPlatform } from '@ionic/react';
-import { IonReactRouter } from '@ionic/react-router';
+import { IonReactHashRouter } from '@ionic/react-router';
 import MainMenu from './components/MainMenu';
 import ProtectedRoute from './components/ProtectedRoute';
 import useIsMounted from './hooks/use-is-mounted';
@@ -62,7 +62,7 @@ const App: FC = () => {
     <IonApp>
       <AuthLoginContextProvider>
         <AuthRegisterContextProvider>
-          <IonReactRouter>
+          <IonReactHashRouter>
             <MainMenu />
             <Switch>
               <Route path="/qr/:id" component={QrCodeGeneratorPage} exact />
@@ -125,7 +125,7 @@ const App: FC = () => {
                 <ProtectedRoute path="/market/card/createnewauction/:cardId/:minimumBid/:minimumIncrement/:finalBiddingDate" component={AuctionCreationAndConfirmationPage} exact />                                         
               </IonRouterOutlet>
             </Switch>
-          </IonReactRouter>
+          </IonReactHashRouter>
         </AuthRegisterContextProvider>
       </AuthLoginContextProvider>
     </IonApp>

--- a/src/store/epics/collections.ts
+++ b/src/store/epics/collections.ts
@@ -87,7 +87,7 @@ const fetchWalletCollectionsEpic: RootEpic = (
                 data.push(asset);
               }              
             }                
-            return CollectiblesLoadSuccessAction(q, data, data.length < q.limit!);
+            return CollectiblesLoadSuccessAction(q, data, data.length < q.limit!); 
           }),
           catchError((err) => of(CollectiblesLoadErrorAction(err)))
         );            
@@ -196,12 +196,12 @@ const fetchCardsOnAuctionEpic: RootEpic = (
                   startedBiddingDate: auction.timestamp.human,
                   timeRemaining: days + "d" + hours + "h" + minutes + "m",
                   highestBidId: highestBidId,                  
-                  currentBid: maxBid,
+                  currentBid: maxBid / 10 ^ 8,
               };
               if (!onlyOwnAuctions){
                 if (myBid > 0){
                   asset.attributes = { ...asset.attributes, 
-                    yourBid: myBid,
+                    yourBid: myBid / 10 ^ 8,
                     bidId: myBidId,
                   };         
                 }       


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Changed back to IonRouteHash navigation in order to work with gitpages
Added adaptation to 8 decimales NASCAR coin format to avoid very little amounts
### What changes are being made?
Changed back to IonRouteHash navigation
Changed epics write/read to 10^8 format
### Why are these changes necessary?
To improve user experience
<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [X] Ready to be merged

<!-- Feel free to add additional comments. -->

